### PR TITLE
fix: node 404

### DIFF
--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -1,4 +1,4 @@
-class Node < Formula
+class NodeAT18 < Formula
   desc "Platform built on V8 to build network applications"
   homepage "https://nodejs.org/"
   url "https://nodejs.org/dist/v18.19.1/node-v18.19.1.tar.xz"


### PR DESCRIPTION
```
==> Downloading https://ghcr.io/v2/homebrew/core/node/blobs/sha256:6ceb39cdb19984aed3125dff77678c77d136c40a492742a01d7aac6921e802ef
curl: (22) The requested URL returned error: 404
Error: node: Failed to download resource "node"
Download failed: https://ghcr.io/v2/homebrew/core/node/blobs/sha256:6ceb39cdb19984aed3125dff77678c77d136c40a492742a01d7aac6921e802ef
```

I suspect this is due to the change of name. Unsure how this will play with the file being called `node.rb` 🤷  lets find out together