### PR TITLE
Update python@3.10.rb

### DIFF
--- a/Formula/python@3.10.rb
+++ b/Formula/python@3.10.rb
@@ -26,7 +26,7 @@ class PythonAT310 < Formula
   depends_on "pkg-config" => :build
   depends_on "gdbm"
   depends_on "mpdecimal"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "readline"
   depends_on "sqlite"
   depends_on "xz"


### PR DESCRIPTION
Change the dependency on openssl@1.1 to openssl@3 as per https://github.com/Homebrew/homebrew-core/blob/d09e5a99b78a3dd37fd84231c0436939bf1eef88/Formula/p/python%403.10.rb


Homebrew no longer supports openssl@1.1, it was EOLed upstream in 2023