### PR TITLE
feat: upgrading postman-cli to 1.17.0

### DIFF
--- a/Formula/postman-cli.rb
+++ b/Formula/postman-cli.rb
@@ -1,26 +1,26 @@
-cask "postman-cli" do
-  arch arm: "osx_arm64", intel: "osx64"
+cask 'postman-cli' do
+  arch arm: 'osx_arm64', intel: 'osx64'
 
-  version "1.7.1"
-  sha256 arm:   "b55151baafd04085d7d1c56814916f76404c182cb4e88060e1414d85a2d924dd",
-         intel: "4f414d29588345b55ff88df992d82412af8e6e68800f0a667bc3e404c8b6e59c"
+  version '1.17.0'
+  sha256 arm: '96fdb63ca09db68a5bd75ecefdd3e3ef99ec37da977b3bf054e12f28f4d605e3',
+         intel: 'a9e65b842cdcbbe4e8682d6c8c07932bb8cadfc808f35256e454205af50ea4a4'
 
   url "https://dl-cli.pstmn.io/download/version/#{version}/#{arch}",
-      verified: "dl-cli.pstmn.io/download/"
-  name "Postman CLI"
-  desc "CLI for command-line API management on Postman"
-  homepage "https://www.postman.com/downloads/"
+      verified: 'dl-cli.pstmn.io/download/'
+  name 'Postman CLI'
+  desc 'CLI for command-line API management on Postman'
+  homepage 'https://www.postman.com/downloads/'
 
   livecheck do
-    url "https://dl-cli.pstmn.io/api/version/latest"
+    url 'https://dl-cli.pstmn.io/api/version/latest'
     strategy :json do |json|
-      json["version"]
+      json['version']
     end
   end
 
   auto_updates true
 
-  binary "postman-cli", target: "postman"
+  binary 'postman-cli', target: 'postman'
 
-  zap trash: "~/.postman"
+  zap trash: '~/.postman'
 end


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Upgraded Postman CLI to version 1.17.0 in the Homebrew formula to provide the latest features and fixes.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Postman CLI to version 1.17.0 with revised checksums for both ARM and Intel.
  * Improved consistency in formatting and style throughout the cask definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->